### PR TITLE
use a neutral pronoun to avoid gendering the users

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Missing interfaces for HTTP-Client middlewares using PSR-7 messages.
 
 The goal is to provide interfaces that you can depend on in your applications
 and non-http libraries. This way we can implement independent code and everyone
-can use whatever HTTP client he wants.
+can use whatever HTTP client they want.
 
 There are three abstractions/levels of implementation possible. Every one of
 them is optional!


### PR DESCRIPTION
Hello! This is a simple change to avoid gendering users and alienating non-male users. :)
Cheers!
